### PR TITLE
Chile fix

### DIFF
--- a/examples/dbpedia/main.py
+++ b/examples/dbpedia/main.py
@@ -61,8 +61,12 @@ def print_time(results, target, metadata=None):
     for result in results["results"]["bindings"]:
         offset = result[target]["value"].replace(u"−", u"-")
 
-        if "to" in offset:
-            from_offset, to_offset = offset.split("to")
+        if ("to" in offset) or ("and" in offset):
+            if "to" in offset:
+                from_offset, to_offset = offset.split("to")
+            else:
+                from_offset, to_offset = offset.split("and")
+
             from_offset, to_offset = int(from_offset), int(to_offset)
 
             if from_offset > to_offset:
@@ -77,7 +81,7 @@ def print_time(results, target, metadata=None):
             location_string = random.choice(["where you are",
                                              "your location"])
 
-            print "Between %s and %s, depending %s" % \
+            print "Between %s and %s, depending on %s" % \
                   (from_time.strftime("%H:%M"),
                    to_time.strftime("%H:%M on %A"),
                    location_string)

--- a/examples/dbpedia/main.py
+++ b/examples/dbpedia/main.py
@@ -63,8 +63,10 @@ def print_time(results, target, metadata=None):
 
         if ("to" in offset) or ("and" in offset):
             if "to" in offset:
+                connector = "and"
                 from_offset, to_offset = offset.split("to")
             else:
+                connector = "or"
                 from_offset, to_offset = offset.split("and")
 
             from_offset, to_offset = int(from_offset), int(to_offset)
@@ -81,8 +83,9 @@ def print_time(results, target, metadata=None):
             location_string = random.choice(["where you are",
                                              "your location"])
 
-            print "Between %s and %s, depending on %s" % \
+            print "Between %s %s %s, depending on %s" % \
                   (from_time.strftime("%H:%M"),
+                   connector,
                    to_time.strftime("%H:%M on %A"),
                    location_string)
 


### PR DESCRIPTION
It seems that the latest dbpedia dump has slightly updated information for the timezone of Chile.

This pull request fixes this problem by introducing "and" as a split word (dbpedia currently returns "-4 and -6" for Chile) and also slightly altering the response.
