### PR TITLE
Update installation.rst to include dependency in doctopt

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,7 @@ Dependeces
 * `nltk <http://nltk.org/>`_ - *if you intend to use nltk tagger*
 * `SPARQLWrapper <http://pypi.python.org/pypi/SPARQLWrapper>`_ *if you intend to use the examples*
 * `graphviz <http://www.graphviz.org/>`_ *if you intend to visulize your queries*
-
+* `doctopt <https://github.com/docopt/docopt>`_ *For beautiful command-line interfaces*
 
 From pip
 --------


### PR DESCRIPTION
To include the dependency on `doctopt` which quepy is using. Also need to include it in **dependency list** in `setup.py`.
