### PR TITLE
Adding docopt as a dependency

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,6 +8,8 @@ Dependencies
 * `nltk <http://nltk.org/>`_ - *if you intend to use nltk tagger*
 * `SPARQLWrapper <http://pypi.python.org/pypi/SPARQLWrapper>`_ *if you intend to use the examples*
 * `graphviz <http://www.graphviz.org/>`_ *if you intend to visualize your queries*
+* `doctopt <https://github.com/docopt/docopt>`_ *For beautiful command-line interfaces*
+
 
 
 From pip


### PR DESCRIPTION
add docopt as dependency

I just simply did this pull request-https://github.com/machinalis/quepy/pull/9
