### PR TITLE
Updated to new POS Tagger

### DIFF
--- a/quepy/nltktagger.py
+++ b/quepy/nltktagger.py
@@ -12,7 +12,7 @@ Tagging using NLTK.
 """
 
 # Requiered data files are:
-#   - "maxent_treebank_pos_tagger" in Models
+#   - "averaged_perceptron_tagger" in Models
 #   - "wordnet" in Corpora
 
 import nltk

--- a/scripts/quepy
+++ b/scripts/quepy
@@ -197,7 +197,7 @@ def nltkdata(path):
     except OSError:
         pass
     nltk.download("wordnet", path)
-    nltk.download("maxent_treebank_pos_tagger", path)
+    nltk.download("averaged_perceptron_tagger", path)
     print "Finished"
 
 


### PR DESCRIPTION
As NLTK has made the perceptron tagger the [default POS tagger](https://github.com/nltk/nltk/issues/1148), the same has to be reflected in Quepy.

PR for the same.

Fixes #40 