### PR TITLE
docs: fix simple typo, beacuse -> because

### DIFF
--- a/quepy/mql_generation.py
+++ b/quepy/mql_generation.py
@@ -58,7 +58,7 @@ def post_order_depth_first(graph, start):
     Iterate over the nodes of the graph (is a tree) in a way such that every
     node is preceded by it's childs.
     `graph` is a dict that represents the `Expression` graph. It's a tree too
-    beacuse Expressions are trees.
+    because Expressions are trees.
     `start` is the node to use as the root of the tree.
     """
     q = [start]


### PR DESCRIPTION
There is a small typo in quepy/mql_generation.py.

Should read `because` rather than `beacuse`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md